### PR TITLE
Add the ability to replace relative file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Default: `['.js', '.css', '.html', '.hbs']`
 
 Only substitute in new filenames in files of these types.
 
+##### replaceRelative
+
+Type: `Boolean`<br>
+Default: `true`
+
+Replace relative files like `url(../image/foo.jpg)` in files with reved filename.
+
 ##### prefix
 
 Type: `String`

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (options) {
 	let renames = [];
 	const cache = [];
 
-	options = Object.assign({canonicalUris: true, replaceInExtensions: ['.js', '.css', '.html', '.hbs']}, options);
+	options = Object.assign({canonicalUris: true, replaceInExtensions: ['.js', '.css', '.html', '.hbs'], replaceRelative: true}, options);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -76,7 +76,9 @@ module.exports = function (options) {
 				});
 
 				const contents = file.contents.toString();
-				let newContents = replace(contents, modifiedRenames);
+
+				const filePath = options.replaceRelative ? fmtPath(file.base, file.path) : undefined;
+				let newContents = replace(contents, modifiedRenames, filePath);
 
 				if (options.prefix) {
 					newContents = newContents.split('/' + options.prefix).join(options.prefix);

--- a/lib/replace.js
+++ b/lib/replace.js
@@ -5,6 +5,7 @@ const escapeRegExp = require('lodash.escaperegexp');
 
 module.exports = function (string, manifest, filePath) {
 	let newString = string;
+
 	manifest.forEach(entry => {
 		const {unreved, reved} = entry;
 
@@ -25,8 +26,9 @@ module.exports = function (string, manifest, filePath) {
 		);
 
 		if (filePath) {
-			const relativeUnreved = path.relative(filePath, unreved);
-			const relativeReved = path.relative(filePath, reved);
+			const fileDir = path.dirname(filePath);
+			const relativeUnreved = path.relative(fileDir, unreved);
+			const relativeReved = path.relative(fileDir, reved);
 
 			const relativeRegexp = new RegExp(
 				`([${FRONT_DELIMITERS.join('')}]|^)(${escapeRegExp(

--- a/lib/replace.js
+++ b/lib/replace.js
@@ -1,8 +1,9 @@
 'use strict';
 
+const path = require('path');
 const escapeRegExp = require('lodash.escaperegexp');
 
-module.exports = function (string, manifest) {
+module.exports = function (string, manifest, filePath) {
 	let newString = string;
 	manifest.forEach(entry => {
 		const {unreved, reved} = entry;
@@ -22,6 +23,24 @@ module.exports = function (string, manifest) {
 			(match, frontDelimiter, unreved, backDelimiter) =>
 				`${frontDelimiter}${reved}${backDelimiter}`
 		);
+
+		if (filePath) {
+			const relativeUnreved = path.relative(filePath, unreved);
+			const relativeReved = path.relative(filePath, reved);
+
+			const relativeRegexp = new RegExp(
+				`([${FRONT_DELIMITERS.join('')}]|^)(${escapeRegExp(
+					relativeUnreved
+				)})([${BACK_DELIMITERS.join('')}]|$)`,
+				'g'
+			);
+
+			newString = newString.replace(
+				relativeRegexp,
+				(match, frontDelimiter, relativeUnreved, backDelimiter) =>
+					`${frontDelimiter}${relativeReved}${backDelimiter}`
+			);
+		}
 	});
 	return newString;
 };

--- a/test/replace.spec.js
+++ b/test/replace.spec.js
@@ -81,6 +81,15 @@ test('fragment identifiers', t => {
 	t.is(output, expected);
 });
 
+test('relative paths', t => {
+	const input = 'body { background: url("../icon.svg#fragment"); }';
+	const expected =
+    'body { background: url("../icon-d41d8cd98f.svg#fragment"); }';
+	const output = replace(input, renames, 'images/test.css');
+
+	t.is(output, expected);
+});
+
 test('equality signs', t => {
 	const input = '/*# sourceMappingURL=style.css.map */';
 	const expected = '/*# sourceMappingURL=style-98adc164tm.css.map */';

--- a/test/replace.spec.js
+++ b/test/replace.spec.js
@@ -82,10 +82,10 @@ test('fragment identifiers', t => {
 });
 
 test('relative paths', t => {
-	const input = 'body { background: url("../icon.svg#fragment"); }';
+	const input = 'body { background: url("../images/icon.svg#fragment"); }';
 	const expected =
-    'body { background: url("../icon-d41d8cd98f.svg#fragment"); }';
-	const output = replace(input, renames, 'images/test.css');
+    'body { background: url("../images/icon-d41d8cd98f.svg#fragment"); }';
+	const output = replace(input, renames, 'css/test.css');
 
 	t.is(output, expected);
 });


### PR DESCRIPTION
In a project where I'm using `gulp-rev-rewrite`, we have a mix of references to absolute and relative file names (in CSS files), some of which we don't have control over and where we can't use `modify*`.

I think this feature might be useful to others as well. It basically adds the option to do replacements like `../images/awesome-image.png` to `../images/awesome-image-12345abcd.png`, with respect to the path of the file being changed.