### PR TITLE
Support for quote-less attributes.

### DIFF
--- a/lib/replace.js
+++ b/lib/replace.js
@@ -8,7 +8,7 @@ module.exports = function (string, manifest) {
 		const {unreved, reved} = entry;
 
 		const FRONT_DELIMITERS = ['"', '\'', '\\s', ',', '\\(', '\\/', '=', '^', '%2F'];
-		const BACK_DELIMITERS = ['"', '\'', '\\s', ',', '\\)', '\\\\', '\\?', '#', '$', '&'];
+		const BACK_DELIMITERS = ['"', '\'', '\\s', ',', '\\)', '\\\\', '\\?', '#', '$', '&', '>'];
 
 		const regexp = new RegExp(
 			`(?<=${FRONT_DELIMITERS.join('|')})${escapeRegExp(

--- a/test/replace.spec.js
+++ b/test/replace.spec.js
@@ -113,3 +113,12 @@ test('commas', t => {
 
 	t.is(output, expected);
 });
+
+test('attributes without quotes', t => {
+	const input = '<img src=https://assets.cdn.com/myaccount/myimage.jpg>';
+	const expected = '<img src=https://assets.cdn.com/myaccount/myimage-0b61c88d26.jpg>';
+	const customRenames = [{unreved: 'myimage.jpg', reved: 'myimage-0b61c88d26.jpg'}];
+	const output = replace(input, customRenames);
+
+	t.is(output, expected);
+});

--- a/test/replace.spec.js
+++ b/test/replace.spec.js
@@ -115,10 +115,9 @@ test('commas', t => {
 });
 
 test('attributes without quotes', t => {
-	const input = '<img src=https://assets.cdn.com/myaccount/myimage.jpg>';
-	const expected = '<img src=https://assets.cdn.com/myaccount/myimage-0b61c88d26.jpg>';
-	const customRenames = [{unreved: 'myimage.jpg', reved: 'myimage-0b61c88d26.jpg'}];
-	const output = replace(input, customRenames);
+	const input = '<img src=images/icon.svg>';
+	const expected = '<img src=images/icon-d41d8cd98f.svg>';
+	const output = replace(input, renames);
 
 	t.is(output, expected);
 });


### PR DESCRIPTION
HTML standard permits some attributes to not be surrounded with quotes. This is not currently supported though.