### PR TITLE
[Tested & Working] Added the ability to reverse the rewrite process via the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Type: `String`
 
 Add a prefix to each replacement.
 
+##### reverse
+
+Type: `Boolean`
+
+Reverse the filename replacing procedure.
+
 ##### modifyUnreved, modifyReved
 
 Type: `Function`

--- a/index.js
+++ b/index.js
@@ -54,8 +54,14 @@ module.exports = function (options = {}) {
 			options.manifest.on('data', file => {
 				const manifest = JSON.parse(file.contents.toString());
 
-				for (const [unreved, reved] of Object.entries(manifest)) {
-					renames.push({unreved, reved});
+				if (options.reverse) {
+					for (const [reved, unreved] of Object.entries(manifest)) {
+						renames.push({unreved, reved});
+					}
+				} else {
+					for (const [unreved, reved] of Object.entries(manifest)) {
+						renames.push({unreved, reved});
+					}
 				}
 			});
 			options.manifest.on('end', replaceContents);


### PR DESCRIPTION
I am using this functionality to alter twig files so I need to undo the previous rev in order to do another.

Here's my `rewriteRevert` function.

```js
function rewriteRevert(done) {
    const filePath = `${buildDirectory}/rev-manifest.json`;
    const manifest = fs.existsSync(filePath) && src(filePath);

    if (!manifest) {
        return done();
    }

    return src('src/Views/**/*.twig')
        .pipe(revRewrite({manifest, reverse: true}))
        .pipe(dest('src/Views'));
}
```